### PR TITLE
don't remove indentation in yaml

### DIFF
--- a/lib/content.js
+++ b/lib/content.js
@@ -4,7 +4,7 @@ exports.getFrontMatter = function(lines) {
     lines.shift();
     var line;
     // Keep shifting off lines till we find the next ---
-    while (!(/^---/).test(line = lines.shift().trim())) {
+    while (!(/^---/).test(line = lines.shift())) {
       frontMatter.push(line);
     } 
     return frontMatter.join('\n');


### PR DESCRIPTION
The trimming converts:
```yaml
person:
  name: "a name"
  age: "40"
```
to
```yaml
person:
name: "a name"
age: "40"
```
which distorts/destroys the intended yaml structure.

I'm guessing you want to trim whitespace on the right side of the line perhaps? Either way, this fixes my problem :)